### PR TITLE
Add link to browse page to download zip of all rdats

### DIFF
--- a/media/html/public_browse.html
+++ b/media/html/public_browse.html
@@ -62,7 +62,7 @@
 							</div>
 						</a>
 					</div>
-					<a href="/site_data/all_rdat.zip">
+					<a href="/site_data/published_rdat.zip">
 						<button type="button" class="btn btn-outline-primary" style="width: 100%; display:flex; justify-content: center; align-items: center;">
 							<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-cloud-download" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" style="margin-right: 4px;">
 								<path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
@@ -157,4 +157,5 @@
 {% block script %}
 	<script type="text/javascript" src="/site_media/js/public/{{DEBUG_DIR}}browse{{DEBUG_STR}}.js"></script>  
 {% endblock %}
+
 

--- a/media/html/public_browse.html
+++ b/media/html/public_browse.html
@@ -14,46 +14,65 @@
 				<div class="panel-body scroll_nav">
 					<div class="list-group">
 						<a class="list-group-item active alert-default nav-list-item" id="buttonAll">
-							<h4 class="list-group-item-heading">
-								<span class="glyphicon glyphicon-inbox" aria-hidden="true"></span>
-              					&nbsp;&nbsp;All
-              				</h4>
-							<p class="list-group-item-text">
-								# Entries: 
-								<span class="badge" id="N_all"></span>
-							</p>
+							<div>
+								<h4 class="list-group-item-heading">
+									<span class="glyphicon glyphicon-inbox" aria-hidden="true"></span>
+									&nbsp;&nbsp;All
+								</h4>
+								<p class="list-group-item-text">
+									# Entries: 
+									<span class="badge" id="N_all"></span>
+								</p>
+							</div>
 						</a>
 						<a class="list-group-item alert-danger nav-list-item" id="buttonGeneral">
-							<h4 class="list-group-item-heading">
-								<span class="glyphicon glyphicon-heart" aria-hidden="true"></span>
-              					&nbsp;&nbsp;General
-              				</h4>
-							<p class="list-group-item-text">
-								# Entries: 
-								<span class="badge" id="N_general"></span>
-							</p>
+							<div>
+								<h4 class="list-group-item-heading">
+									<span class="glyphicon glyphicon-heart" aria-hidden="true"></span>
+									&nbsp;&nbsp;General
+								</h4>
+								<p class="list-group-item-text">
+									# Entries: 
+									<span class="badge" id="N_general"></span>
+								</p>
+							</div>
 						</a>
 						<a class="list-group-item alert-success nav-list-item" id="buttonPuzzle">
-							<h4 class="list-group-item-heading">
-								<span class="glyphicon glyphicon-screenshot" aria-hidden="true"></span>
-              					&nbsp;&nbsp;RNA Puzzles
-              				</h4>
-							<p class="list-group-item-text">
-								# Entries: 
-								<span class="badge" id="N_puzzle"></span>
-							</p>
+							<div>
+								<h4 class="list-group-item-heading">
+									<span class="glyphicon glyphicon-screenshot" aria-hidden="true"></span>
+									&nbsp;&nbsp;RNA Puzzles
+								</h4>
+								<p class="list-group-item-text">
+									# Entries: 
+									<span class="badge" id="N_puzzle"></span>
+								</p>	
+							</div>
 						</a>
 						<a class="list-group-item alert-info nav-list-item" id="buttonEterna">
-							<h4 class="list-group-item-heading">
-								<span class="glyphicon glyphicon-cloud" aria-hidden="true"></span>
-              					&nbsp;&nbsp;Eterna
-              				</h4>
-							<p class="list-group-item-text">
-								# Entries: 
-								<span class="badge" id="N_eterna"></span>
-							</p>
+							<div>
+								<h4 class="list-group-item-heading">
+									<span class="glyphicon glyphicon-cloud" aria-hidden="true"></span>
+									&nbsp;&nbsp;Eterna
+								</h4>
+								<p class="list-group-item-text">
+									# Entries: 
+									<span class="badge" id="N_eterna"></span>
+								</p>
+							</div>
 						</a>
 					</div>
+					<a href="/site_data/all_rdat.zip">
+						<button type="button" class="btn btn-outline-primary" style="width: 100%; display:flex; justify-content: center; align-items: center;">
+							<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-cloud-download" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round" style="margin-right: 4px;">
+								<path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+								<path d="M19 18a3.5 3.5 0 0 0 0 -7h-1a5 4.5 0 0 0 -11 -2a4.6 4.4 0 0 0 -2.1 8.4"></path>
+								<path d="M12 13l0 9"></path>
+								<path d="M9 19l3 3l3 -3"></path>
+						</svg>
+							Download Selected Files
+						</button>
+					</a>
 				</div>
 			</div>
 

--- a/src/management/commands/zip_rdat.py
+++ b/src/management/commands/zip_rdat.py
@@ -6,7 +6,7 @@ import zipfile
 
 from django.core.management.base import BaseCommand
 
-
+from src.models import RMDBEntry
 from src.settings import *
 
 
@@ -19,6 +19,25 @@ class Command(BaseCommand):
         flag = False
 
         try:
+            ### Zip published RDATS for batch download
+            entryDict = {}
+            zf = zipfile.ZipFile('%s/data/published_rdat.zip' % MEDIA_ROOT, 'w', zipfile.ZIP_DEFLATED)
+            
+            # Grab each published entry and define the path to the associated RDAT file
+            # We don't write the zip file here because we have multiple versions with the same id
+            # which is handled by writing the entry rdat dir to a dict keyed by rmdb_id
+            entries = RMDBEntry.objects.all().filter(status='PUB')
+            for entry in list(entries):
+                entryDict[entry.rmdb_id] = '%s%s' % (PATH.DATA_DIR['FILE_DIR'], entry.rmdb_id)
+
+            # For each entry, get the path to the associated rdat and write to zip file
+            for rmdb_id in entryDict:
+                rdatPath = '%s/%s.rdat' % (entryDict[rmdb_id], rmdb_id)
+                if os.path.exists(rdatPath):
+                    zf.write(rdatPath,'%s.rdat' % rmdb_id)
+            zf.close()
+
+            ### Zip all RDATS for backup
             all_rdats = [i for i in os.listdir(PATH.DATA_DIR['FILE_DIR']) if (not i.startswith('.') and i != "search")]
             zf = zipfile.ZipFile('%s/data/all_rdat.zip' % MEDIA_ROOT, 'w', zipfile.ZIP_DEFLATED)
             for rdat_name in all_rdats:


### PR DESCRIPTION
The RMDB site used to have the option to download a zipped directory of all the published RDATs, and the backend still runs a script to generate this `all_rdats.zip` file. This PR adds a download link to the browse page to allow researchers to download this file.

Closes #75.