### PR TITLE
Fix memory leak in file uploads

### DIFF
--- a/src/util/entry.py
+++ b/src/util/entry.py
@@ -141,6 +141,7 @@ def process_upload(form, formset, upload_file, user):
                     print traceback.format_exc()
                     error_msg.append('Invaid RDAT file; please check and resubmit.')
                     flag = 1
+            rf.close()
 
         if not flag:
             flag = 2

--- a/src/util/media.py
+++ b/src/util/media.py
@@ -158,7 +158,9 @@ def save_json_heatmap(entry):
         data_mean = mean(data_mean)
 
         json = {'data': data_matrix, 'peak_max': data_max, 'peak_min': round(data_min, 3), 'peak_mean': round(data_mean, 3), 'peak_sd': round(data_sd, 3), 'row_lim': row_limits, 'x_labels': x_labels, 'y_labels': y_labels, 'precalc_structures': precalc_structures}
-        simplejson.dump(json, open('%s/%s-hmap.json' % (PATH.DATA_DIR['JSON_DIR'], entry.rmdb_id), 'w'), sort_keys=True, indent=' ' * 4)
+        f = open('%s/%s-hmap.json' % (PATH.DATA_DIR['JSON_DIR'], entry.rmdb_id), 'w')
+        simplejson.dump(json, f, sort_keys=True, indent=' ' * 4)
+        f.close()
     except ConstructSection.DoesNotExist:
         return None
 
@@ -209,7 +211,9 @@ def save_json_tags(entry):
     tags_construct = {'sequence': c.sequence, 'structure': c.structure, 'offset': c.offset, 'sequence_len': len(c.sequence), 'structure_len': len(c.structure), 'data_nrow': len(c.datas), 'data_ncol': len(c.datas[0].values.split(',')), 'err_ncol': c.err_ncol, 'xsel_len': c.xsel_len, 'seqpos_len': c.seqpos_len, 'seqpos': c.seqpos, 'name': c.name}
 
     tags_all = dict(tags_basic.items() + tags_construct.items() + tags_annotation.items())
-    simplejson.dump(tags_all, open('%s/%s-tags.json' % (PATH.DATA_DIR['JSON_DIR'], entry.rmdb_id), 'w'), sort_keys=True, indent=' ' * 4)
+    f = open('%s/%s-tags.json' % (PATH.DATA_DIR['JSON_DIR'], entry.rmdb_id), 'w')
+    simplejson.dump(tags_all, f, sort_keys=True, indent=' ' * 4)
+    f.close()
 
 
 def save_json(rmdb_id):

--- a/src/util/util.py
+++ b/src/util/util.py
@@ -38,7 +38,9 @@ def get_entry_version(rmdb_id):
 
 
 def temp_file(file_name):
-    open('%s/%s' % (PATH.DATA_DIR['TMP_DIR'], file_name.name), 'w').write(file_name.read())
+    f = open('%s/%s' % (PATH.DATA_DIR['TMP_DIR'], file_name.name), 'w')
+    f.write(file_name.read())
+    f.close()
     return open('%s/%s' % (PATH.DATA_DIR['TMP_DIR'], file_name.name), 'r')
 
 

--- a/src/views.py
+++ b/src/views.py
@@ -27,6 +27,7 @@ from src.settings import EMAIL_HOST_USER
 from datetime import datetime
 import simplejson
 # import traceback
+import gc
 
 dist_dict = {'mapseeker': 'MAPseeker', 'reeffit': 'REEFFIT', 'hitrace': 'HiTRACE', 'rdatkit': 'RDATKit', 'biers': 'Biers'}
 
@@ -256,6 +257,7 @@ def validate(request):
 
     if flag == -1:
         (messages, errors, flag, form) = ([], [], 0, ValidateForm())
+    gc.collect()
     return render(request, PATH.HTML_PATH['validate'], {'form': form, 'val_errs': errors, 'val_msgs': messages, 'flag': flag})
 
 
@@ -289,6 +291,7 @@ def upload(request):
 
     if not flag:
         (error_msg, flag, entry, form, formset) = ([], 0, '', UploadForm(), CoOwnersFormSet())
+    gc.collect()
     return render(request, PATH.HTML_PATH['upload'], {'form': form,
                                                       'formset': formset,
                                                       'error_msg': error_msg,


### PR DESCRIPTION
* When creating temp files on disk from file uploads, the file opened for writing was never closed
* Run garbage collection more aggressively after running validate and upload calls, to ensure memory is reclaimed in a timely fashion after large uploads