### PR TITLE
Remove check that RMDB contains experimentType annotation

### DIFF
--- a/src/util/entry.py
+++ b/src/util/entry.py
@@ -120,9 +120,6 @@ def process_upload(form, formset, upload_file, user):
                 if exp_type != 'StandardState':
                     flag = 1
                     error_msg.append('Use StandardState for Eterna entries.')
-            elif exp_type != 'MOHCA':
-                flag = 1
-                error_msg.append('Missing experimentType.')
 
             rf.seek(0)
             if form.cleaned_data['file_type'] == 'isatab':


### PR DESCRIPTION
Per discussion with Rhiju on Slack:
> It's no longer really used for any downstream application and is provided during RMDB submission only