### PR TITLE
Update detail page with link to view publication related entries

### DIFF
--- a/media/html/public_browse_table.html
+++ b/media/html/public_browse_table.html
@@ -173,6 +173,8 @@
 					
 					// Create input element
 					let input = document.createElement('input');
+					// Populate element with search from URL querystring if present
+					input.value = new URLSearchParams(window.location.search).get(`${this.dataSrc()}`) ?? ''
 					input.placeholder = title;
 					column.header().replaceChildren(input);
 					
@@ -182,6 +184,9 @@
 							column.search(input.value).draw();
 						}
 					});
+
+					// Search and draw column with query populated search term
+					column.search(input.value).draw();
 				});
 
 				// Force redraw to address responsive column width issue

--- a/media/html/public_detail.html
+++ b/media/html/public_detail.html
@@ -448,7 +448,9 @@
                             {{ pubmed_info|citation_format }}
                         {% endautoescape %}
                     </p>
-
+										<button>
+											<a id="link_relatedEntries" href="/browse/table">View related RMDB entries for this publication</a>
+										</button>
 					<p><span class="lead" id="show_description"><span class="label label-brown">Description</span></span></p>
 					<p id="tag_description"></p>
 					<p style="padding-top:5px;" id="show_pdb">

--- a/media/js/public/view_tags.js
+++ b/media/js/public/view_tags.js
@@ -72,6 +72,7 @@ function fill_tags() {
     if(/^\d+$/.test(tags.pubmed_id)) {
         $("#tag_pubmed").text(tags.pubmed_id);
         $("#link_pubmed").attr("href", "http://www.ncbi.nlm.nih.gov/pubmed/" + tags.pubmed_id);
+        $("#link_relatedEntries").attr("href", "/browse/table?pubmed_id=" + tags.pubmed_id);
     }else{
         $("#link_pubmed").css("display", "none");
         $("#show_publication").css("display", "none");


### PR DESCRIPTION
An entry's detail view page now includes a button (if there is an associated publication and pubmed_id) to view other entries associated with that publication. The button links to the table view query populated to search by pubmed id.

![Screenshot 2024-07-24 at 16-09-33 RMDB RNA Mapping DataBase](https://github.com/user-attachments/assets/1eaa20fd-be07-49a1-b3bc-e2e5ca40c692)
